### PR TITLE
Add release digest workflow

### DIFF
--- a/.github/workflows/release-digest.yml
+++ b/.github/workflows/release-digest.yml
@@ -1,0 +1,89 @@
+name: Release Digest
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # Runs every day at 9:00 AM UTC
+  workflow_dispatch:
+
+env:
+  TARGET_REPO: mautic/mautic
+
+jobs:
+  check-milestones:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check milestones due today
+        id: check
+        run: |
+          TODAY=$(date -u +"%Y-%m-%d")
+          echo "Checking milestones due on: $TODAY"
+
+          MILESTONES=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ env.TARGET_REPO }}/milestones?state=open&per_page=100")
+
+          DUE_TODAY=$(echo "$MILESTONES" | jq --arg today "$TODAY" '
+            [.[] | select(.due_on != null and (.due_on | startswith($today)))]
+          ')
+
+          COUNT=$(echo "$DUE_TODAY" | jq 'length')
+          echo "Milestones due today: $COUNT"
+
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          echo "milestones=$(echo $DUE_TODAY | jq -c .)" >> $GITHUB_OUTPUT
+
+      - name: Build Slack message
+        if: steps.check.outputs.count > 0
+        id: message
+        run: |
+          MILESTONES='${{ steps.check.outputs.milestones }}'
+          REPO="${{ env.TARGET_REPO }}"
+
+          BLOCKS=$(echo "$MILESTONES" | jq -c --arg repo "$REPO" '
+            [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "🚀 Release Digest — Due Today"
+                }
+              },
+              {
+                "type": "divider"
+              }
+            ] +
+            [.[] |
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": (
+                    "Milestone name: *<" + .html_url + "|" + .title + ">*\n" +
+                    "\n🟡 Open issues/PRs: " + (.open_issues | tostring) +
+                    "\n✅ Closed issues/PRs: " + (.closed_issues | tostring) +
+                    if .description != null and .description != ""
+                      then "\n\n" + .description
+                      else ""
+                    end +
+                    "\n\n<" + .html_url + "|🔗 View Milestone>"
+                  )
+                },
+                "accessory": {
+                  "type": "button",
+                  "text": { "type": "plain_text", "text": "View Milestone" },
+                  "url": .html_url
+                }
+              }
+            ]
+          ')
+
+          echo "blocks=$(echo $BLOCKS | jq -c .)" >> $GITHUB_OUTPUT
+
+      - name: Send Slack notification
+        if: steps.check.outputs.count > 0
+        run: |
+          curl -s -X POST "${{ secrets.SLACK_RELEASE_DIGEST_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"blocks\": $(echo '${{ steps.message.outputs.blocks }}')}"

--- a/.github/workflows/release-digest.yml
+++ b/.github/workflows/release-digest.yml
@@ -13,76 +13,122 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check milestones due today
+      - name: Check milestones
         id: check
         run: |
           TODAY=$(date -u +"%Y-%m-%d")
-          echo "Checking milestones due on: $TODAY"
+          echo "Checking milestones for: $TODAY"
 
           MILESTONES=$(curl -s \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ env.TARGET_REPO }}/milestones?state=open&per_page=100")
 
-          DUE_TODAY=$(echo "$MILESTONES" | jq --arg today "$TODAY" '
-            [.[] | select(.due_on != null and (.due_on | startswith($today)))]
-          ')
+          get_date_offset() {
+            date -u -d "+$1 days" +"%Y-%m-%d"
+          }
 
-          COUNT=$(echo "$DUE_TODAY" | jq 'length')
-          echo "Milestones due today: $COUNT"
+          DATE_0=$(get_date_offset 0)
+          DATE_1=$(get_date_offset 1)
+          DATE_7=$(get_date_offset 7)
+          DATE_14=$(get_date_offset 14)
 
-          echo "count=$COUNT" >> $GITHUB_OUTPUT
-          echo "milestones=$(echo $DUE_TODAY | jq -c .)" >> $GITHUB_OUTPUT
+          filter_milestones() {
+            echo "$MILESTONES" | jq --arg date "$1" '
+              [.[] | select(.due_on != null and (.due_on | startswith($date)))]
+            '
+          }
+
+          DUE_0=$(filter_milestones "$DATE_0")
+          DUE_1=$(filter_milestones "$DATE_1")
+          DUE_7=$(filter_milestones "$DATE_7")
+          DUE_14=$(filter_milestones "$DATE_14")
+
+          echo "due_today=$(echo $DUE_0 | jq -c .)"   >> $GITHUB_OUTPUT
+          echo "due_1=$(echo $DUE_1 | jq -c .)"       >> $GITHUB_OUTPUT
+          echo "due_7=$(echo $DUE_7 | jq -c .)"       >> $GITHUB_OUTPUT
+          echo "due_14=$(echo $DUE_14 | jq -c .)"     >> $GITHUB_OUTPUT
+
+          echo "count_today=$(echo $DUE_0 | jq 'length')"   >> $GITHUB_OUTPUT
+          echo "count_1=$(echo $DUE_1 | jq 'length')"       >> $GITHUB_OUTPUT
+          echo "count_7=$(echo $DUE_7 | jq 'length')"       >> $GITHUB_OUTPUT
+          echo "count_14=$(echo $DUE_14 | jq 'length')"     >> $GITHUB_OUTPUT
 
       - name: Build Slack message
-        if: steps.check.outputs.count > 0
+        if: |
+          steps.check.outputs.count_today > 0 ||
+          steps.check.outputs.count_1 > 0 ||
+          steps.check.outputs.count_7 > 0 ||
+          steps.check.outputs.count_14 > 0
         id: message
         run: |
-          MILESTONES='${{ steps.check.outputs.milestones }}'
-          REPO="${{ env.TARGET_REPO }}"
+          build_section() {
+            local MILESTONES="$1"
+            local HEADER="$2"
 
-          BLOCKS=$(echo "$MILESTONES" | jq -c --arg repo "$REPO" '
-            [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "🚀 Release Digest — Due Today"
-                }
-              },
-              {
-                "type": "divider"
-              }
-            ] +
-            [.[] |
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": (
-                    "Milestone name: *<" + .html_url + "|" + .title + ">*\n" +
-                    "\n🟡 Open issues/PRs: " + (.open_issues | tostring) +
-                    "\n✅ Closed issues/PRs: " + (.closed_issues | tostring) +
-                    if .description != null and .description != ""
-                      then "\n\n" + .description
-                      else ""
-                    end +
-                    "\n\n<" + .html_url + "|🔗 View Milestone>"
-                  )
-                },
-                "accessory": {
-                  "type": "button",
-                  "text": { "type": "plain_text", "text": "View Milestone" },
-                  "url": .html_url
-                }
-              }
-            ]
-          ')
+            echo "$MILESTONES" | jq -c --arg header "$HEADER" '
+              if length == 0 then []
+              else
+                [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": $header
+                    }
+                  },
+                  {
+                    "type": "divider"
+                  }
+                ] +
+                [.[] |
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": (
+                        "Milestone name: *<" + .html_url + "|" + .title + ">*\n" +
+                        "\n🟡 Open issues/PRs: " + (.open_issues | tostring) +
+                        "\n✅ Closed issues/PRs: " + (.closed_issues | tostring) +
+                        if .description != null and .description != ""
+                          then "\n\n" + .description
+                          else ""
+                        end +
+                        "\n\n<" + .html_url + "|🔗 View Milestone>"
+                      )
+                    },
+                    "accessory": {
+                      "type": "button",
+                      "text": { "type": "plain_text", "text": "View Milestone" },
+                      "url": .html_url
+                    }
+                  }
+                ]
+              end
+            '
+          }
+
+          SECTION_TODAY=$(build_section '${{ steps.check.outputs.due_today }}' "🚀 Release Digest — Due Today")
+          SECTION_1=$(build_section     '${{ steps.check.outputs.due_1 }}'     "🔔 Release Digest — Due Tomorrow")
+          SECTION_7=$(build_section     '${{ steps.check.outputs.due_7 }}'     "⚠️ Release Digest — Due in 1 Week")
+          SECTION_14=$(build_section    '${{ steps.check.outputs.due_14 }}'    "⏳ Release Digest — Due in 2 Weeks")
+
+          BLOCKS=$(jq -cn \
+            --argjson s0  "$SECTION_TODAY" \
+            --argjson s1  "$SECTION_1" \
+            --argjson s7  "$SECTION_7" \
+            --argjson s14 "$SECTION_14" \
+            '$s14 + $s7 + $s1 + $s0'
+          )
 
           echo "blocks=$(echo $BLOCKS | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Send Slack notification
-        if: steps.check.outputs.count > 0
+        if: |
+          steps.check.outputs.count_today > 0 ||
+          steps.check.outputs.count_1 > 0 ||
+          steps.check.outputs.count_7 > 0 ||
+          steps.check.outputs.count_14 > 0
         run: |
           curl -s -X POST "${{ secrets.SLACK_RELEASE_DIGEST_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
This PR adds a scheduled GitHub Actions workflow that checks for milestones due today and sends a notification to the release team Slack channel. This workflow ensures that the release team is automatically reminded on the day a release or version is due, without needing to manually check GitHub milestones.

<img width="472" height="402" alt="image" src="https://github.com/user-attachments/assets/227d1ecc-a5ec-467d-8a2d-ee791d7f6eb3" />


How it works:
- Runs daily at 9:00 AM UTC
- Fetches all open milestones from `mautic/mautic`
- Filters milestones where due date matches today
- If any are found, sends a formatted digest to Slack with milestone title, open/closed issues/PRs count, description and a link

Before merging this PR, follow these steps:

1. Create a Slack app if one doesn’t already exist: https://api.slack.com/apps?new_app=1  
   - Select **"From scratch"**  
   - Enter an app name eg "Mautic"
   - Select the Mautic workspace  
2. In the left sidebar, go to **"Incoming Webhooks"**
3. Click **"Add New Webhook"**
4. Select **#release-team** as the channel
5. Click **"Allow"**
6. Copy the webhook URL and add it to this repository as a secret named `SLACK_RELEASE_DIGEST_WEBHOOK_URL`

<img width="1170" height="1061" alt="image" src="https://github.com/user-attachments/assets/5963f1d9-9603-4f76-8104-a3805f51ac74" />