### PR TITLE
Remove redundant view milestone link

### DIFF
--- a/.github/workflows/release-digest.yml
+++ b/.github/workflows/release-digest.yml
@@ -93,8 +93,7 @@ jobs:
                         if .description != null and .description != ""
                           then "\n\n" + .description
                           else ""
-                        end +
-                        "\n\n<" + .html_url + "|🔗 View Milestone>"
+                        end
                       )
                     },
                     "accessory": {


### PR DESCRIPTION
Since the milestone name is already linked and there is a "View Milestone" button, the additional "View Milestone" link actually seems unnecessary. This PR removes it.