### PR TITLE
pass step outputs via env vars to prevent shell quoting errors

### DIFF
--- a/.github/workflows/release-digest.yml
+++ b/.github/workflows/release-digest.yml
@@ -61,6 +61,11 @@ jobs:
           steps.check.outputs.count_7 > 0 ||
           steps.check.outputs.count_14 > 0
         id: message
+        env:
+          DUE_TODAY: ${{ steps.check.outputs.due_today }}
+          DUE_3: ${{ steps.check.outputs.due_3 }}
+          DUE_7: ${{ steps.check.outputs.due_7 }}
+          DUE_14: ${{ steps.check.outputs.due_14 }}
         run: |
           build_section() {
             local MILESTONES="$1"
@@ -107,10 +112,10 @@ jobs:
             '
           }
 
-          SECTION_TODAY=$(build_section '${{ steps.check.outputs.due_today }}' "🚀 Release Digest — Due Today")
-          SECTION_3=$(build_section     '${{ steps.check.outputs.due_3 }}'     "🔔 Release Digest — Due in 3 Days")
-          SECTION_7=$(build_section     '${{ steps.check.outputs.due_7 }}'     "⚠️ Release Digest — Due in 1 Week")
-          SECTION_14=$(build_section    '${{ steps.check.outputs.due_14 }}'    "⏳ Release Digest — Due in 2 Weeks")
+          SECTION_TODAY=$(build_section "$DUE_TODAY" "🚀 Release Digest — Due Today")
+          SECTION_3=$(build_section     "$DUE_3"     "🔔 Release Digest — Due in 3 Days")
+          SECTION_7=$(build_section     "$DUE_7"     "⚠️ Release Digest — Due in 1 Week")
+          SECTION_14=$(build_section    "$DUE_14"    "⏳ Release Digest — Due in 2 Weeks")
 
           BLOCKS=$(jq -cn \
             --argjson s0  "$SECTION_TODAY" \
@@ -128,7 +133,10 @@ jobs:
           steps.check.outputs.count_3 > 0 ||
           steps.check.outputs.count_7 > 0 ||
           steps.check.outputs.count_14 > 0
+        env:
+          SLACK_BLOCKS: ${{ steps.message.outputs.blocks }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_DIGEST_WEBHOOK_URL }}
         run: |
-          curl -s -X POST "${{ secrets.SLACK_RELEASE_DIGEST_WEBHOOK_URL }}" \
+          curl -s -X POST "$SLACK_WEBHOOK" \
             -H "Content-Type: application/json" \
-            -d "{\"blocks\": $(echo '${{ steps.message.outputs.blocks }}')}"
+            -d "{\"blocks\": $SLACK_BLOCKS}"


### PR DESCRIPTION
GitHub Actions workflow run failed today: https://github.com/mautic/.github/actions/runs/25663823979/job/75331028146

```bash
/home/runner/work/_temp/382b8a28-f3d2-41d3-9811-5f404275e16d.sh: line 59: unexpected EOF while looking for matching `"'
```

The error comes from using `${{ steps.check.outputs.due_14 }}` directly inside shell strings. GitHub Actions expands `${{ }}` expressions before the shell runs, and since those outputs contain raw JSON with double quotes, it breaks the shell's quoting and causes the unexpected EOF.